### PR TITLE
variable subst. action is deprecated

### DIFF
--- a/.github/workflows/ansible-galaxy-publish.yml
+++ b/.github/workflows/ansible-galaxy-publish.yml
@@ -28,11 +28,9 @@ jobs:
           ref: master
 
       - name: update galaxy.yml with new version
-        uses: microsoft/variable-substitution@v1
+        uses: mikefarah/yq@master
         with:
-          files: 'galaxy.yml'
-        env:
-          version: "${{ github.event.release.tag_name }}"
+          cmd: yq -i '.version = "${{ github.event.release.tag_name }}"' 'galaxy.yml'
 
       - name: push galaxy.yml
         uses: github-actions-x/commit@v2.9


### PR DESCRIPTION
the action is deprecated: https://github.com/microsoft/variable-substitution.

replace it with yq.

Tested here:
https://github.com/rndmh3ro/ansible-collection-icinga-director/actions/runs/3445497175