### PR TITLE
auto-merge minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "dependencyDashboardAutoclose": true,
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
We use Renovate to keep our workflows up to date. Since functional changes in minior releases rarely break stuff and we update only our workflows, not some package content, this should be acceptable. When an update breaks a workflow we should adapt anyways :D