### PR TITLE
Add GH_BRANCH_PROTECTION_APP_TOKEN to workflow

### DIFF
--- a/.github/workflows/ansible-galaxy-role-publish.yml
+++ b/.github/workflows/ansible-galaxy-role-publish.yml
@@ -7,6 +7,9 @@ on:
       GALAXY_API_KEY:
         description: 'The API-key to publish to Ansible Galaxy'
         required: true
+      GH_BRANCH_PROTECTION_APP_TOKEN:
+        description: 'The token used to push as a Github-app. Globally set in the organization'
+        required: true
 
 jobs:
   deploy_to_galaxy:


### PR DESCRIPTION
Add GH_BRANCH_PROTECTION_APP_TOKEN to workflow to avoid the error `The workflow is not valid. .github/workflows/galaxy.yml (Line: 16, Col: 39): Invalid secret, GH_BRANCH_PROTECTION_APP_TOKEN is not defined in the referenced workflow.` by using this workflow